### PR TITLE
feat: add CoupleProfile page

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 import { Container } from '@mui/material';
 
-import { ProfilePage } from '@/pages-layer/profile';
+import { CouplePage } from '@/pages-layer/couple';
 
 import { authGuard } from '@/features/auth';
 
@@ -9,8 +9,8 @@ import { APP_ROUTE } from '@/shared/constants';
 export default async function Profile() {
   await authGuard(APP_ROUTE.PROFILE, ['traveler']);
   return (
-    <Container maxWidth="lg">
-      <ProfilePage />
+    <Container maxWidth="md">
+      <CouplePage />
     </Container>
   );
 }

--- a/src/entities/operator/model/useOperatorQuery.ts
+++ b/src/entities/operator/model/useOperatorQuery.ts
@@ -1,21 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { useUserQuery } from '@/entities/user';
+
 import { useAccessTokenStore } from '@/shared/session';
 
 import { operatorApi } from '../api/operatorApi';
 import { OperatorMe } from '../api/types';
 
 export const useOperatorQuery = () => {
+  const { data: user } = useUserQuery();
   const accessToken = useAccessTokenStore((s) => s.accessToken);
-  const isAccessToken = !!accessToken;
+
+  const isOperator = !!accessToken && user?.role === 'operator';
+
   return useQuery<OperatorMe | null>({
     queryKey: ['operator', 'me'],
-    queryFn: async () => {
-      return operatorApi.getOperatorMe();
-    },
-    staleTime: 1000 * 60 * 1,
-    refetchOnMount: isAccessToken,
-    refetchOnWindowFocus: isAccessToken,
-    retry: 1,
+    queryFn: () => operatorApi.getOperatorMe(),
+    staleTime: 1000 * 60 * 5,
+    enabled: isOperator,
+    retry: 0,
   });
 };

--- a/src/entities/user/api/types.ts
+++ b/src/entities/user/api/types.ts
@@ -14,3 +14,12 @@ export interface User {
   phone: string | null;
   role: UserRole;
 }
+
+export type UserUpdate = {
+  firstPersonName?: string | null;
+  firstPersonSurname?: string | null;
+  secondPersonName?: string | null;
+  secondPersonSurname?: string | null;
+  phone?: string | null;
+  email?: string | null;
+};

--- a/src/entities/user/api/userApi.ts
+++ b/src/entities/user/api/userApi.ts
@@ -1,6 +1,6 @@
-import { axiosInstance } from '@/shared/api';
+import { axiosInstance, handleApiError } from '@/shared/api';
 
-import { User } from './types';
+import { User, UserUpdate } from './types';
 
 export const userApi = {
   getCurrentUser: async (accessToken?: string): Promise<User | null> => {
@@ -13,6 +13,14 @@ export const userApi = {
       return res.data;
     } catch {
       throw new Error('Failed to fetch current user');
+    }
+  },
+  updateUserData: async (body: UserUpdate): Promise<User> => {
+    try {
+      const res = await axiosInstance.patch<User>('/user', body);
+      return res.data;
+    } catch (e: unknown) {
+      handleApiError(e);
     }
   },
 };

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,3 +1,3 @@
 export { useUserQuery } from './model/useUserQuery';
 export { userApi } from './api/userApi';
-export type { User } from './api/types';
+export type { User, UserUpdate } from './api/types';

--- a/src/entities/user/model/useUserQuery.ts
+++ b/src/entities/user/model/useUserQuery.ts
@@ -8,15 +8,12 @@ import { User } from '../api/types';
 
 export const useUserQuery = () => {
   const accessToken = useAccessTokenStore((s) => s.accessToken);
-  const isAccessToken = !!accessToken;
+
   return useQuery<User | null>({
     queryKey: ['user', 'me'],
-    queryFn: async () => {
-      return userApi.getCurrentUser();
-    },
-    staleTime: 1000 * 60 * 1,
-    refetchOnMount: isAccessToken,
-    refetchOnWindowFocus: isAccessToken,
+    queryFn: () => userApi.getCurrentUser(),
+    staleTime: 1000 * 60 * 5,
+    enabled: !!accessToken,
     retry: 1,
   });
 };

--- a/src/features/couple-profile/index.ts
+++ b/src/features/couple-profile/index.ts
@@ -1,0 +1,1 @@
+export { CoupleProfile } from './ui/CoupleProfile';

--- a/src/features/couple-profile/model/schema.ts
+++ b/src/features/couple-profile/model/schema.ts
@@ -1,24 +1,34 @@
 import { matchIsValidTel } from 'mui-tel-input';
 import { z } from 'zod';
 
-// лише літери, апострофи і дефіси
-const onlyValidCharsRegex = /^[\p{L}'-]+$/u;
+// літери, апострофи (прямий ' та ’), дефіси та пробіли між словами
+const onlyValidCharsRegex = /^[\p{L}\u2019'\-\s]+$/u;
 
 // заборона подвійних дефісів і апострофів
-const noDoubleSymbolsRegex = /^(?!.*-{2})(?!.*'{2}).*$/u;
+const noDoubleSymbolsRegex = /^(?!.*-{2})(?!.*['\u2019]{2}).*$/u;
 
 // заборона дефісів на початку і в кінці
 const noEdgeHyphenRegex = /^(?!-)(?!.*-$).*$/;
 
+// заборона подвійних пробілів та пробілу на початку/в кінці
+const noDoubleSpacesRegex = /^(?!.*\s{2,}).*$/u;
+const noEdgeSpaceRegex = /^(?!\s)(?!.*\s$).*$/u;
+
 export const stringWithValidNameChars = z
   .string()
-  .min(2, { message: 'Введіть від 2 до 100 символів' })
-  .max(100, { message: 'Введіть від 2 до 100 символів' })
+  .min(2, { message: 'Введіть від 2 до 100 символів.' })
+  .max(100, { message: 'Введіть від 2 до 100 символів.' })
   .regex(onlyValidCharsRegex, {
-    message: 'Дозволено лише літери, дефіси (-) та апострофи (’).',
+    message: 'Дозволено лише літери, пробіли, дефіси (-) та апострофи (’)',
   })
   .regex(noDoubleSymbolsRegex, {
     message: 'Не допускаються подвійні дефіси чи апострофи.',
+  })
+  .regex(noDoubleSpacesRegex, {
+    message: 'Не допускаються подвійні пробіли.',
+  })
+  .regex(noEdgeSpaceRegex, {
+    message: 'Пробіл не може бути на початку або в кінці.',
   })
   .regex(noEdgeHyphenRegex, {
     message: 'Дефіс не може бути на початку або в кінці.',

--- a/src/features/couple-profile/model/schema.ts
+++ b/src/features/couple-profile/model/schema.ts
@@ -1,0 +1,41 @@
+import { matchIsValidTel } from 'mui-tel-input';
+import { z } from 'zod';
+
+// лише літери, апострофи і дефіси
+const onlyValidCharsRegex = /^[\p{L}'-]+$/u;
+
+// заборона подвійних дефісів і апострофів
+const noDoubleSymbolsRegex = /^(?!.*-{2})(?!.*'{2}).*$/u;
+
+// заборона дефісів на початку і в кінці
+const noEdgeHyphenRegex = /^(?!-)(?!.*-$).*$/;
+
+export const stringWithValidNameChars = z
+  .string()
+  .min(2, { message: 'Введіть від 2 до 100 символів' })
+  .max(100, { message: 'Введіть від 2 до 100 символів' })
+  .regex(onlyValidCharsRegex, {
+    message: 'Дозволено лише літери, дефіси (-) та апострофи (’).',
+  })
+  .regex(noDoubleSymbolsRegex, {
+    message: 'Не допускаються подвійні дефіси чи апострофи.',
+  })
+  .regex(noEdgeHyphenRegex, {
+    message: 'Дефіс не може бути на початку або в кінці.',
+  });
+
+export const coupleProfileSchema = z.object({
+  firstPersonName: stringWithValidNameChars.nullish(),
+  firstPersonSurname: stringWithValidNameChars.nullish(),
+  secondPersonName: stringWithValidNameChars.nullish(),
+  secondPersonSurname: stringWithValidNameChars.nullish(),
+  phone: z
+    .string()
+    .refine((value) => matchIsValidTel(value), {
+      message: 'Введіть коректний номер телефону',
+    })
+    .nullish(),
+  email: z.email().nullish(),
+});
+
+export type CoupleProfileSchemaValues = z.infer<typeof coupleProfileSchema>;

--- a/src/features/couple-profile/model/useCoupleProfileForm.tsx
+++ b/src/features/couple-profile/model/useCoupleProfileForm.tsx
@@ -41,7 +41,7 @@ export const useCoupleProfileForm = ({ onCancel }: UseCoupleProfileProps) => {
       phone: user?.phone,
     },
     resolver: zodResolver(coupleProfileSchema),
-    mode: 'onTouched',
+    mode: 'onSubmit',
   });
 
   const { watch } = form;
@@ -50,7 +50,6 @@ export const useCoupleProfileForm = ({ onCancel }: UseCoupleProfileProps) => {
   if (user) {
     isChanged = Object.keys(getChangedValues(user, watchedValues)).length > 0;
   }
-
   const onSubmit = async (data: CoupleProfileSchemaValues) => {
     if (user) {
       const changed = getChangedValues(user, data);

--- a/src/features/couple-profile/model/useCoupleProfileForm.tsx
+++ b/src/features/couple-profile/model/useCoupleProfileForm.tsx
@@ -1,0 +1,70 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+
+import { useUserQuery, userApi } from '@/entities/user';
+import { User, UserUpdate } from '@/entities/user';
+
+import { useNotificationStore } from '@/shared/store';
+import { getChangedValues } from '@/shared/utils';
+
+import { CoupleProfileSchemaValues, coupleProfileSchema } from './schema';
+
+interface UseCoupleProfileProps {
+  onCancel: () => void;
+}
+
+export const useCoupleProfileForm = ({ onCancel }: UseCoupleProfileProps) => {
+  const { data: user } = useUserQuery();
+  const qc = useQueryClient();
+  const showNotification = useNotificationStore((s) => s.showNotification);
+
+  const { mutateAsync, isPending } = useMutation<User, Error, UserUpdate>({
+    mutationFn: (body) => userApi.updateUserData(body),
+    onSuccess: (data) => {
+      qc.setQueryData(['user', 'me'], data);
+      showNotification('Профіль оновлено', 'success');
+      onCancel();
+    },
+    onError: (error) => {
+      showNotification(error.message, 'error');
+    },
+  });
+
+  const form = useForm<CoupleProfileSchemaValues>({
+    defaultValues: {
+      email: user?.email,
+      firstPersonName: user?.firstPersonName,
+      firstPersonSurname: user?.firstPersonSurname,
+      secondPersonName: user?.secondPersonName,
+      secondPersonSurname: user?.secondPersonSurname,
+      phone: user?.phone,
+    },
+    resolver: zodResolver(coupleProfileSchema),
+    mode: 'onTouched',
+  });
+
+  const { watch } = form;
+  const watchedValues = watch();
+  let isChanged = false;
+  if (user) {
+    isChanged = Object.keys(getChangedValues(user, watchedValues)).length > 0;
+  }
+
+  const onSubmit = async (data: CoupleProfileSchemaValues) => {
+    if (user) {
+      const changed = getChangedValues(user, data);
+
+      if (Object.keys(changed).length === 0) {
+        return;
+      } else {
+        try {
+          await mutateAsync(changed);
+        } catch (e) {
+          console.error('Mutation failed:', e);
+        }
+      }
+    }
+  };
+  return { form, onSubmit, isPending, isChanged };
+};

--- a/src/features/couple-profile/ui/CoupleProfile.tsx
+++ b/src/features/couple-profile/ui/CoupleProfile.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Box, Typography } from '@mui/material';
+
+import { useUserQuery } from '@/entities/user';
+
+import { CoupleProfileForm } from './CoupleProfileForm';
+import { CoupleProfileInfo } from './CoupleProfileInfo';
+
+export const CoupleProfile = () => {
+  const [isEdit, setIsEdit] = useState(false);
+  const { data: user } = useUserQuery();
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+    >
+      <Typography align="center" variant="h5" component="h3">
+        Інформація про нас
+      </Typography>
+      {user &&
+        (isEdit ? (
+          <CoupleProfileForm onCancel={() => setIsEdit(false)} />
+        ) : (
+          <CoupleProfileInfo user={user} onEdit={() => setIsEdit(true)} />
+        ))}
+    </Box>
+  );
+};

--- a/src/features/couple-profile/ui/CoupleProfileForm.tsx
+++ b/src/features/couple-profile/ui/CoupleProfileForm.tsx
@@ -18,7 +18,7 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
     handleSubmit,
     register,
     control,
-    formState: { errors, isValid },
+    formState: { errors },
   } = form;
   return (
     <Box
@@ -128,7 +128,7 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
           type="submit"
           variant="contained"
           size="large"
-          disabled={!isValid || !isChanged || isPending}
+          disabled={!isChanged || isPending}
           loading={isPending}
         >
           Зберегти

--- a/src/features/couple-profile/ui/CoupleProfileForm.tsx
+++ b/src/features/couple-profile/ui/CoupleProfileForm.tsx
@@ -1,0 +1,148 @@
+import type { FC } from 'react';
+
+import { Box, Button, TextField } from '@mui/material';
+import { MuiTelInput } from 'mui-tel-input';
+import { Controller } from 'react-hook-form';
+
+import { useCoupleProfileForm } from '../model/useCoupleProfileForm';
+
+interface CoupleProfileForm {
+  onCancel: () => void;
+}
+
+export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
+  const { form, onSubmit, isChanged, isPending } = useCoupleProfileForm({
+    onCancel,
+  });
+  const {
+    handleSubmit,
+    register,
+    control,
+    formState: { errors, isValid },
+  } = form;
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit(onSubmit)}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        maxWidth: 778,
+        width: '100%',
+        margin: '0 auto',
+      }}
+    >
+      <TextField
+        label="Ім’я партнера 1"
+        placeholder="Ім’я партнера 1"
+        {...register('firstPersonName')}
+        error={!!errors.firstPersonName}
+        helperText={errors.firstPersonName?.message}
+        fullWidth
+        variant="outlined"
+      />
+
+      <TextField
+        label="Прізвище партнера 1"
+        placeholder="Прізвище партнера 1"
+        {...register('firstPersonSurname')}
+        error={!!errors.firstPersonSurname}
+        helperText={errors.firstPersonSurname?.message}
+        fullWidth
+        variant="outlined"
+      />
+      <TextField
+        label="Ім’я партнера 2"
+        placeholder="Ім’я партнера 2"
+        {...register('secondPersonName')}
+        error={!!errors.secondPersonName}
+        helperText={errors.secondPersonName?.message}
+        fullWidth
+        variant="outlined"
+      />
+
+      <TextField
+        label="Прізвище партнера 2"
+        placeholder="Прізвище партнера 2"
+        {...register('secondPersonSurname')}
+        error={!!errors.secondPersonSurname}
+        helperText={errors.secondPersonSurname?.message}
+        fullWidth
+        variant="outlined"
+      />
+
+      <Controller
+        name="phone"
+        control={control}
+        render={({ field, fieldState }) => (
+          <MuiTelInput
+            label="Номер телефону"
+            {...field}
+            value={field.value ?? ''}
+            defaultCountry="UA"
+            forceCallingCode
+            preferredCountries={['UA', 'US']}
+            continents={['EU', 'NA']}
+            disableFormatting
+            focusOnSelectCountry
+            error={!!fieldState.error}
+            helperText={fieldState.error?.message}
+            variant="outlined"
+            MenuProps={{
+              PaperProps: {
+                style: {
+                  maxHeight: 250,
+                  width: 493,
+                },
+              },
+              disablePortal: true,
+              anchorOrigin: {
+                vertical: 'bottom',
+                horizontal: 'left',
+              },
+            }}
+          />
+        )}
+      />
+
+      <TextField
+        label="Електронна пошта"
+        placeholder="Електронна пошта"
+        {...register('email')}
+        error={!!errors.email}
+        helperText={errors.email?.message}
+        fullWidth
+        disabled
+        variant="outlined"
+      />
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '20px',
+          alignSelf: 'center',
+        }}
+      >
+        <Button
+          type="submit"
+          variant="contained"
+          size="large"
+          disabled={!isValid || !isChanged || isPending}
+          loading={isPending}
+        >
+          Зберегти
+        </Button>
+        <Button
+          type="button"
+          variant="contained"
+          size="large"
+          onClick={onCancel}
+          disabled={isPending}
+        >
+          Скасувати
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/src/features/couple-profile/ui/CoupleProfileInfo.tsx
+++ b/src/features/couple-profile/ui/CoupleProfileInfo.tsx
@@ -12,6 +12,8 @@ interface CoupleProfileInfo {
   user: User;
 }
 
+const NOT_FILLED_TEXT = 'Не заповнено';
+
 export const CoupleProfileInfo: FC<CoupleProfileInfo> = ({ user, onEdit }) => {
   const {
     phone,
@@ -30,19 +32,15 @@ export const CoupleProfileInfo: FC<CoupleProfileInfo> = ({ user, onEdit }) => {
       }}
     >
       <Typography>
-        {`${firstPersonName || ''} ${firstPersonSurname || ''}`}
+        {`${firstPersonName || NOT_FILLED_TEXT} ${firstPersonSurname || NOT_FILLED_TEXT}`}
       </Typography>
-      {(secondPersonName || secondPersonName) && (
-        <Typography>
-          {`${secondPersonName || ''} ${secondPersonSurname || ''}`}
-        </Typography>
-      )}
-      {phone && (
-        <Box sx={{ display: 'flex', gap: '14px', alignItems: 'center' }}>
-          <LocalPhoneOutlinedIcon />
-          <Typography>{phone}</Typography>
-        </Box>
-      )}
+      <Typography>
+        {`${secondPersonName || NOT_FILLED_TEXT} ${secondPersonSurname || NOT_FILLED_TEXT}`}
+      </Typography>
+      <Box sx={{ display: 'flex', gap: '14px', alignItems: 'center' }}>
+        <LocalPhoneOutlinedIcon />
+        <Typography>{phone || NOT_FILLED_TEXT}</Typography>
+      </Box>
       {email && <Typography>{user.email}</Typography>}
       <Button
         onClick={onEdit}

--- a/src/features/couple-profile/ui/CoupleProfileInfo.tsx
+++ b/src/features/couple-profile/ui/CoupleProfileInfo.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { FC } from 'react';
+
+import LocalPhoneOutlinedIcon from '@mui/icons-material/LocalPhoneOutlined';
+import { Box, Button, Typography } from '@mui/material';
+
+import type { User } from '@/entities/user';
+
+interface CoupleProfileInfo {
+  onEdit: () => void;
+  user: User;
+}
+
+export const CoupleProfileInfo: FC<CoupleProfileInfo> = ({ user, onEdit }) => {
+  const {
+    phone,
+    email,
+    firstPersonName,
+    firstPersonSurname,
+    secondPersonName,
+    secondPersonSurname,
+  } = user;
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+    >
+      <Typography>
+        {`${firstPersonName || ''} ${firstPersonSurname || ''}`}
+      </Typography>
+      {(secondPersonName || secondPersonName) && (
+        <Typography>
+          {`${secondPersonName || ''} ${secondPersonSurname || ''}`}
+        </Typography>
+      )}
+      {phone && (
+        <Box sx={{ display: 'flex', gap: '14px', alignItems: 'center' }}>
+          <LocalPhoneOutlinedIcon />
+          <Typography>{phone}</Typography>
+        </Box>
+      )}
+      {email && <Typography>{user.email}</Typography>}
+      <Button
+        onClick={onEdit}
+        variant="contained"
+        sx={{ width: 'fit-content', placeSelf: 'center' }}
+      >
+        Редагувати
+      </Button>
+    </Box>
+  );
+};

--- a/src/pages-layer/couple/index.ts
+++ b/src/pages-layer/couple/index.ts
@@ -1,0 +1,1 @@
+export { CouplePage } from './ui/CouplePage';

--- a/src/pages-layer/couple/ui/CouplePage.tsx
+++ b/src/pages-layer/couple/ui/CouplePage.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { CoupleProfile } from '@/features/couple-profile';
+
 import { Tabs } from '@/shared/ui';
 
-export const ProfilePage = () => {
+export const CouplePage = () => {
   const tabs = [
     {
       label: 'Інформація про нас',
-      content: <>Наша інформація, форма редагування нашої інформацї</>,
+      content: <CoupleProfile />,
     },
     { label: 'Наші бронювання', content: <>Наші бронювання</> },
   ];

--- a/src/pages-layer/profile/index.ts
+++ b/src/pages-layer/profile/index.ts
@@ -1,1 +1,0 @@
-export { ProfilePage } from './ui/ProfilePage';

--- a/src/shared/utils/getChangedValues.ts
+++ b/src/shared/utils/getChangedValues.ts
@@ -1,0 +1,21 @@
+export function getChangedValues<T extends Record<string, unknown>>(
+  initial: T,
+  current: T,
+): Partial<T> {
+  const result = {} as Partial<T>;
+
+  for (const key of Object.keys(current) as Array<keyof T>) {
+    const prev = initial[key];
+    const next = current[key];
+
+    // Нормалізуємо null і '' як "однаково пусті"
+    const normalize = (val: unknown) =>
+      val === null || val === '' ? undefined : val;
+
+    if (normalize(prev) !== normalize(next)) {
+      result[key] = next;
+    }
+  }
+
+  return result;
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export { isPublicPath } from './access';
+export { getChangedValues } from './getChangedValues';

--- a/src/widgets/Footer/Footer.tsx
+++ b/src/widgets/Footer/Footer.tsx
@@ -1,13 +1,13 @@
-import { Box, Button, Container, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 
 import { AUTH_URL } from '@/shared/constants/auth';
 import { APP_ROUTE } from '@/shared/constants/routes';
 
 export const Footer = () => {
   return (
-    <Container
-      maxWidth="xl"
+    <Box
       sx={{
+        maxwidth: '100%',
         background: '#272727',
         padding: 5,
         display: 'flex',
@@ -35,6 +35,6 @@ export const Footer = () => {
           Стати партнером
         </Button>
       </Box>
-    </Container>
+    </Box>
   );
 };

--- a/src/widgets/Footer/Footer.tsx
+++ b/src/widgets/Footer/Footer.tsx
@@ -7,7 +7,7 @@ export const Footer = () => {
   return (
     <Box
       sx={{
-        maxwidth: '100%',
+        maxWidth: '100%',
         background: '#272727',
         padding: 5,
         display: 'flex',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Couple Profile page with view and edit modes.
  - Add/edit first/second person names, phone (validated), and view-only email; saving updates only changed fields with success/error notifications.

- **UI Improvements**
  - Replaced the Profile page with the Couple page and integrated the new Couple Profile experience.
  - Narrowed page content width for a focused form layout.
  - Footer updated for full-width presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->