### PR TITLE
refactor: update couple profile page

### DIFF
--- a/src/app/_providers/AppProviders.tsx
+++ b/src/app/_providers/AppProviders.tsx
@@ -28,6 +28,9 @@ export const AppProviders: FC<AppProviderProps> = ({
     operator = null,
     user = null,
   } = userWithToken ?? {};
+  console.log(accessToken, 'accessToken in AppProviders');
+  console.log(operator, 'operator in AppProviders');
+  console.log(user, 'user in AppProviders');
   return (
     <AppRouterCacheProvider options={{ enableCssLayer: true }}>
       <ThemeProvider>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,5 +1,3 @@
-import { Container } from '@mui/material';
-
 import { CouplePage } from '@/pages-layer/couple';
 
 import { authGuard } from '@/features/auth';
@@ -8,9 +6,5 @@ import { APP_ROUTE } from '@/shared/constants';
 
 export default async function Profile() {
   await authGuard(APP_ROUTE.PROFILE, ['traveler']);
-  return (
-    <Container maxWidth="lg">
-      <CouplePage />
-    </Container>
-  );
+  return <CouplePage />;
 }

--- a/src/entities/tour/model/types.ts
+++ b/src/entities/tour/model/types.ts
@@ -1,3 +1,5 @@
+import type { TourCardVariantType } from '@/shared/ui/TourCard/types';
+
 import { useInfiniteToursCollection } from './useInfiniteToursCollection';
 
 export type TourPhotoBack = {
@@ -127,4 +129,6 @@ export type TourBookingInfo = {
 
 export type ToursCollectionProps = ReturnType<
   typeof useInfiniteToursCollection
->;
+> & {
+  variantTourCard?: TourCardVariantType;
+};

--- a/src/entities/tour/model/useInfiniteToursCollection.tsx
+++ b/src/entities/tour/model/useInfiniteToursCollection.tsx
@@ -4,7 +4,7 @@ import { useInView } from 'react-intersection-observer';
 import { Tours } from '@/entities/tour';
 
 interface UseInfiniteToursCollectionProps {
-  initialData: Tours;
+  initialData?: Tours;
   queryKey: (string | number)[];
   queryFn: (params: { limit: number; offset: number }) => Promise<Tours>;
 }
@@ -30,7 +30,7 @@ export const useInfiniteToursCollection = ({
       initialPageParam: 0,
       staleTime: 1000 * 60 * 2,
       refetchOnWindowFocus: true,
-      initialData: {
+      initialData: initialData && {
         pages: [initialData],
         pageParams: [0],
       },

--- a/src/features/booking/lib/useBookingForm.ts
+++ b/src/features/booking/lib/useBookingForm.ts
@@ -11,7 +11,7 @@ import { useBookingStore, useNotificationStore } from '@/shared/store';
 import { useCreateBooking } from './useCreateBooking';
 import { useUpdateUserIfNeeded } from './useUpdateUserIfNeeded';
 
-const bookingFormSchema = coupleProfileSchema.omit({ email: true });
+const bookingFormSchema = coupleProfileSchema;
 type BookingFormSchemaValues = z.infer<typeof bookingFormSchema>;
 
 export const useBookingForm = () => {

--- a/src/features/couple-booking/ui/CoupleBooking.tsx
+++ b/src/features/couple-booking/ui/CoupleBooking.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+
+import { fetchTours, useInfiniteToursCollection } from '@/entities/tour';
+
+import { ToursCollection } from '@/shared/ui';
+
+import { CoupleBookingEmpty } from './CoupleBookingEmpty';
+
+export const CoupleBooking = () => {
+  // TODO: change queryFn to fetch couple bookings
+  const props = useInfiniteToursCollection({
+    queryKey: ['tours', 'my-bookings'],
+    queryFn: fetchTours,
+  });
+
+  const isBookingEmpty = !props.data?.pages?.[0]?.data?.length || props.error;
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+      }}
+      data-testid="couple-profile-editing"
+    >
+      <Typography align="center" variant="h2" component="h2" gutterBottom>
+        Наші бронювання
+      </Typography>
+      {isBookingEmpty ? (
+        <CoupleBookingEmpty />
+      ) : (
+        <ToursCollection {...props} variantTourCard="couple-booking" />
+      )}
+    </Box>
+  );
+};

--- a/src/features/couple-booking/ui/CoupleBooking.tsx
+++ b/src/features/couple-booking/ui/CoupleBooking.tsx
@@ -23,7 +23,7 @@ export const CoupleBooking = () => {
         flexDirection: 'column',
         gap: '24px',
       }}
-      data-testid="couple-profile-editing"
+      data-testid="couple-booking"
     >
       <Typography align="center" variant="h2" component="h2" gutterBottom>
         Наші бронювання

--- a/src/features/couple-booking/ui/CoupleBookingEmpty.tsx
+++ b/src/features/couple-booking/ui/CoupleBookingEmpty.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+import { Box, Button, Typography } from '@mui/material';
+
+import { APP_ROUTE } from '@/shared/constants';
+
+export const CoupleBookingEmpty = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        margin: '0 auto',
+        alignItems: 'center',
+        gap: '24px',
+        justifyContent: 'center',
+        maxWidth: '475px',
+      }}
+    >
+      <Typography variant="bodyLarge">
+        У вас ще немає активних бронювань. Час це виправити!
+      </Typography>
+      <Button
+        LinkComponent={Link}
+        href={APP_ROUTE.CATALOG}
+        variant="contained"
+        color="primary"
+        size="large"
+        sx={{ maxWidth: 200, width: '100%', placeSelf: 'center' }}
+      >
+        До каталогу
+      </Button>
+    </Box>
+  );
+};

--- a/src/features/couple-profile-editing/model/getCoupleProfileData.test.ts
+++ b/src/features/couple-profile-editing/model/getCoupleProfileData.test.ts
@@ -24,6 +24,7 @@ const expectedData: CoupleProfileData = {
   secondPersonName: 'Марія',
   secondPersonSurname: 'Петренко',
   phone: '+380501234567',
+  email: 'test@example.com',
 };
 
 describe('getCoupleProfileData', () => {
@@ -61,6 +62,6 @@ describe('getCoupleProfileData', () => {
     const result = getCoupleProfileData(userWithExtraData);
 
     expect(result).toEqual(expectedData);
-    expect(Object.keys(result).length).toBe(5);
+    expect(Object.keys(result).length).toBe(6);
   });
 });

--- a/src/features/couple-profile-editing/model/getCoupleProfileData.test.ts
+++ b/src/features/couple-profile-editing/model/getCoupleProfileData.test.ts
@@ -54,7 +54,7 @@ describe('getCoupleProfileData', () => {
     );
   });
 
-  it('ignores extra fields such as email', () => {
+  it('ignores extra fields not in CoupleProfileData', () => {
     const userWithExtraData = {
       ...completeUser,
       extraField: 'should be ignored',

--- a/src/features/couple-profile-editing/model/getCoupleProfileData.test.ts
+++ b/src/features/couple-profile-editing/model/getCoupleProfileData.test.ts
@@ -47,6 +47,13 @@ describe('getCoupleProfileData', () => {
     );
   });
 
+  it('throws an error if email is missing', () => {
+    const incompleteUser = { ...completeUser, email: '' };
+    expect(() => getCoupleProfileData(incompleteUser)).toThrow(
+      'Cannot create CoupleProfileData: required fields are missing',
+    );
+  });
+
   it('throws an error if secondPersonSurname is missing', () => {
     const incompleteUser = { ...completeUser, secondPersonSurname: null };
     expect(() => getCoupleProfileData(incompleteUser)).toThrow(

--- a/src/features/couple-profile-editing/model/getCoupleProfileData.ts
+++ b/src/features/couple-profile-editing/model/getCoupleProfileData.ts
@@ -6,6 +6,7 @@ export type CoupleProfileData = {
   secondPersonName: string;
   secondPersonSurname: string;
   phone: string;
+  email: string;
 };
 
 export const getCoupleProfileData = (user: User): CoupleProfileData => {
@@ -14,7 +15,8 @@ export const getCoupleProfileData = (user: User): CoupleProfileData => {
     !user.firstPersonSurname ||
     !user.secondPersonName ||
     !user.secondPersonSurname ||
-    !user.phone
+    !user.phone ||
+    !user.email
   ) {
     throw new Error(
       'Cannot create CoupleProfileData: required fields are missing',
@@ -27,5 +29,6 @@ export const getCoupleProfileData = (user: User): CoupleProfileData => {
     secondPersonName: user.secondPersonName,
     secondPersonSurname: user.secondPersonSurname,
     phone: user.phone,
+    email: user.email,
   };
 };

--- a/src/features/couple-profile-editing/model/schema.test.ts
+++ b/src/features/couple-profile-editing/model/schema.test.ts
@@ -63,18 +63,6 @@ describe('coupleProfileSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects invalid email format', () => {
-    const invalidEmailData = { ...validData, email: 'invalid-email' };
-    const result = coupleProfileSchema.safeParse(invalidEmailData);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === 'email')).toBe(true);
-      expect(
-        result.error.issues.find((i) => i.path[0] === 'email')?.message,
-      ).toBe('Введіть коректну електронну адресу');
-    }
-  });
-
   it('rejects invalid phone number', () => {
     const invalidPhoneData = { ...validData, phone: '123' };
     const result = coupleProfileSchema.safeParse(invalidPhoneData);
@@ -103,17 +91,15 @@ describe('coupleProfileSchema', () => {
       ...validData,
       firstPersonName: ' А ',
       phone: '123',
-      email: 'a@b',
     };
     const result = coupleProfileSchema.safeParse(multipleErrorsData);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(2);
       expect(
         result.error.issues.some((i) => i.path[0] === 'firstPersonName'),
       ).toBe(true);
       expect(result.error.issues.some((i) => i.path[0] === 'phone')).toBe(true);
-      expect(result.error.issues.some((i) => i.path[0] === 'email')).toBe(true);
     }
   });
 });

--- a/src/features/couple-profile-editing/model/schema.ts
+++ b/src/features/couple-profile-editing/model/schema.ts
@@ -42,7 +42,6 @@ export const coupleProfileSchema = z.object({
   phone: z.string().refine((value) => matchIsValidTel(value), {
     message: 'Введіть коректний номер телефону',
   }),
-  email: z.email({ message: 'Введіть коректну електронну адресу' }),
 });
 
 export type CoupleProfileSchemaValues = z.infer<typeof coupleProfileSchema>;

--- a/src/features/couple-profile-editing/model/useCoupleProfileForm.ts
+++ b/src/features/couple-profile-editing/model/useCoupleProfileForm.ts
@@ -33,7 +33,6 @@ export const useCoupleProfileForm = ({ onCancel }: UseCoupleProfileProps) => {
 
   const form = useForm<CoupleProfileSchemaValues>({
     defaultValues: {
-      email: user?.email ?? '',
       firstPersonName: user?.firstPersonName ?? '',
       firstPersonSurname: user?.firstPersonSurname ?? '',
       secondPersonName: user?.secondPersonName ?? '',
@@ -65,5 +64,5 @@ export const useCoupleProfileForm = ({ onCancel }: UseCoupleProfileProps) => {
       console.error('Mutation failed:', e);
     }
   };
-  return { form, onSubmit, isPending };
+  return { form, onSubmit, isPending, email: user?.email };
 };

--- a/src/features/couple-profile-editing/ui/CoupleProfileEditing.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileEditing.tsx
@@ -18,11 +18,10 @@ export const CoupleProfileEditing = () => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        pt: 10,
       }}
       data-testid="couple-profile-editing"
     >
-      <Typography align="center" variant="h1" component="h1" gutterBottom>
+      <Typography align="center" variant="h2" component="h2" gutterBottom>
         Інформація про нас
       </Typography>
 

--- a/src/features/couple-profile-editing/ui/CoupleProfileEditing.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileEditing.tsx
@@ -21,7 +21,7 @@ export const CoupleProfileEditing = () => {
       }}
       data-testid="couple-profile-editing"
     >
-      <Typography align="center" variant="h2" component="h2" gutterBottom>
+      <Typography align="center" variant="h2" component="h1" gutterBottom>
         Інформація про нас
       </Typography>
 

--- a/src/features/couple-profile-editing/ui/CoupleProfileForm.test.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileForm.test.tsx
@@ -64,7 +64,6 @@ describe('CoupleProfileForm', () => {
     expect(screen.getByLabelText('Ім’я партнера 2')).toBeInTheDocument();
     expect(screen.getByLabelText('Прізвище партнера 2')).toBeInTheDocument();
     expect(screen.getByLabelText('Номер телефону')).toBeInTheDocument();
-    expect(screen.getByLabelText('Електронна пошта')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', { name: 'Зберегти' }),
@@ -127,7 +126,6 @@ describe('CoupleProfileForm', () => {
             firstPersonSurname: { message: 'Прізвище обов’язкове 1' },
             secondPersonName: { message: 'Ім’я обов’язкове 2' },
             secondPersonSurname: { message: 'Прізвище обов’язкове 2' },
-            email: { message: 'Невірний email' },
           },
         },
       },
@@ -141,6 +139,5 @@ describe('CoupleProfileForm', () => {
     expect(screen.getByText('Прізвище обов’язкове 1')).toBeInTheDocument();
     expect(screen.getByText('Ім’я обов’язкове 2')).toBeInTheDocument();
     expect(screen.getByText('Прізвище обов’язкове 2')).toBeInTheDocument();
-    expect(screen.getByText('Невірний email')).toBeInTheDocument();
   });
 });

--- a/src/features/couple-profile-editing/ui/CoupleProfileForm.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileForm.tsx
@@ -1,8 +1,15 @@
 import type { FC } from 'react';
 
-import { Box, Button, TextField, styled } from '@mui/material';
-import { MuiTelInput } from 'mui-tel-input';
-import { Controller } from 'react-hook-form';
+import {
+  Box,
+  BoxProps,
+  Button,
+  TextField,
+  Typography,
+  styled,
+} from '@mui/material';
+
+import { PhoneInputField } from '@/shared/ui';
 
 import { useCoupleProfileForm } from '../model/useCoupleProfileForm';
 
@@ -17,6 +24,23 @@ const NameWrapper = styled(Box)({
   width: '100%',
 });
 
+const InputWrapper = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  width: '100%',
+});
+
+const HintWrapper = styled(Box)({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '24px',
+  '& > *:last-child': {
+    width: '100%',
+    maxWidth: '686px',
+  },
+});
+
 const ButtonWrapper = styled(Box)({
   display: 'flex',
   gap: '20px',
@@ -25,8 +49,18 @@ const ButtonWrapper = styled(Box)({
   maxWidth: '420px',
 });
 
+const FormWrapper = styled(Box)<BoxProps>({
+  display: 'flex',
+  flexDirection: 'column',
+  paddingTop: '20px',
+  gap: '20px',
+  maxWidth: '863px',
+  width: '100%',
+  margin: '0 auto',
+});
+
 export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
-  const { form, onSubmit, isPending } = useCoupleProfileForm({
+  const { form, onSubmit, isPending, email } = useCoupleProfileForm({
     onCancel,
   });
   const {
@@ -36,107 +70,82 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
     formState: { errors },
   } = form;
   return (
-    <Box
-      component="form"
-      onSubmit={handleSubmit(onSubmit)}
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        pt: 4,
-        gap: 4,
-        maxWidth: 686,
-        width: '100%',
-        margin: '0 auto',
-      }}
-    >
-      <NameWrapper>
-        <TextField
-          label="Ім’я партнера 1"
-          placeholder="Ім’я партнера 1"
-          {...register('firstPersonName')}
-          error={!!errors.firstPersonName}
-          helperText={errors.firstPersonName?.message}
-          fullWidth
-          variant="outlined"
-        />
+    <FormWrapper component="form" onSubmit={handleSubmit(onSubmit)}>
+      <InputWrapper>
+        <HintWrapper>
+          <Typography
+            variant="bodyDefault"
+            sx={{ padding: '17.5px 0', width: '153px' }}
+          >
+            Ім&apos;я та прізвища:
+          </Typography>
+          <Box sx={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
+            <NameWrapper>
+              <TextField
+                label="Ім’я партнера 1"
+                placeholder="Ім’я партнера 1"
+                {...register('firstPersonName')}
+                error={!!errors.firstPersonName}
+                helperText={errors.firstPersonName?.message}
+                fullWidth
+                variant="outlined"
+              />
 
-        <TextField
-          label="Прізвище партнера 1"
-          placeholder="Прізвище партнера 1"
-          {...register('firstPersonSurname')}
-          error={!!errors.firstPersonSurname}
-          helperText={errors.firstPersonSurname?.message}
-          fullWidth
-          variant="outlined"
-        />
-      </NameWrapper>
+              <TextField
+                label="Прізвище партнера 1"
+                placeholder="Прізвище партнера 1"
+                {...register('firstPersonSurname')}
+                error={!!errors.firstPersonSurname}
+                helperText={errors.firstPersonSurname?.message}
+                fullWidth
+                variant="outlined"
+              />
+            </NameWrapper>
+            <NameWrapper>
+              <TextField
+                label="Ім’я партнера 2"
+                placeholder="Ім’я партнера 2"
+                {...register('secondPersonName')}
+                error={!!errors.secondPersonName}
+                helperText={errors.secondPersonName?.message}
+                fullWidth
+                variant="outlined"
+              />
 
-      <NameWrapper>
-        <TextField
-          label="Ім’я партнера 2"
-          placeholder="Ім’я партнера 2"
-          {...register('secondPersonName')}
-          error={!!errors.secondPersonName}
-          helperText={errors.secondPersonName?.message}
-          fullWidth
-          variant="outlined"
-        />
+              <TextField
+                label="Прізвище партнера 2"
+                placeholder="Прізвище партнера 2"
+                {...register('secondPersonSurname')}
+                error={!!errors.secondPersonSurname}
+                helperText={errors.secondPersonSurname?.message}
+                fullWidth
+                variant="outlined"
+              />
+            </NameWrapper>
+          </Box>
+        </HintWrapper>
 
-        <TextField
-          label="Прізвище партнера 2"
-          placeholder="Прізвище партнера 2"
-          {...register('secondPersonSurname')}
-          error={!!errors.secondPersonSurname}
-          helperText={errors.secondPersonSurname?.message}
-          fullWidth
-          variant="outlined"
-        />
-      </NameWrapper>
-      <Controller
-        name="phone"
-        control={control}
-        render={({ field, fieldState }) => (
-          <MuiTelInput
-            label="Номер телефону"
-            {...field}
-            value={field.value ?? ''}
-            defaultCountry="UA"
-            forceCallingCode
-            preferredCountries={['UA', 'US']}
-            excludedCountries={['RU']}
-            continents={['EU']}
-            disableFormatting
-            focusOnSelectCountry
-            error={!!fieldState.error}
-            helperText={fieldState.error?.message}
-            variant="outlined"
-            MenuProps={{
-              PaperProps: {
-                style: {
-                  maxHeight: 250,
-                  width: 493,
-                },
-              },
-              disablePortal: true,
-              anchorOrigin: {
-                vertical: 'bottom',
-                horizontal: 'left',
-              },
-            }}
-          />
-        )}
-      />
-
-      <TextField
-        label="Електронна пошта"
-        placeholder="Електронна пошта"
-        {...register('email')}
-        error={!!errors.email}
-        helperText={errors.email?.message}
-        fullWidth
-        disabled
-        variant="outlined"
-      />
+        <HintWrapper>
+          <Typography
+            variant="bodyDefault"
+            sx={{ padding: '17.5px 0', width: '153px' }}
+          >
+            Телефон:
+          </Typography>
+          <PhoneInputField control={control} name="phone" />
+        </HintWrapper>
+        <HintWrapper>
+          <Typography
+            variant="bodyDefault"
+            sx={{ padding: '17.5px 0', width: '153px' }}
+          >
+            Електрона пошта:
+          </Typography>
+          <Typography variant="bodyLarge" sx={{ padding: '16.5px 0' }}>
+            {email}
+          </Typography>
+        </HintWrapper>
+      </InputWrapper>
 
       <ButtonWrapper>
         <Button
@@ -162,6 +171,6 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
           Скасувати
         </Button>
       </ButtonWrapper>
-    </Box>
+    </FormWrapper>
   );
 };

--- a/src/features/couple-profile-editing/ui/CoupleProfileForm.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileForm.tsx
@@ -90,7 +90,6 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
                 fullWidth
                 variant="outlined"
               />
-
               <TextField
                 label="Прізвище партнера 1"
                 placeholder="Прізвище партнера 1"
@@ -111,7 +110,6 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
                 fullWidth
                 variant="outlined"
               />
-
               <TextField
                 label="Прізвище партнера 2"
                 placeholder="Прізвище партнера 2"
@@ -139,14 +137,13 @@ export const CoupleProfileForm: FC<CoupleProfileForm> = ({ onCancel }) => {
             variant="bodyDefault"
             sx={{ padding: '17.5px 0', width: '153px' }}
           >
-            Електрона пошта:
+            Електронна пошта:
           </Typography>
           <Typography variant="bodyLarge" sx={{ padding: '16.5px 0' }}>
-            {email}
+            {email ?? '—'}
           </Typography>
         </HintWrapper>
       </InputWrapper>
-
       <ButtonWrapper>
         <Button
           type="submit"

--- a/src/features/couple-profile-editing/ui/CoupleProfileView.test.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileView.test.tsx
@@ -39,6 +39,7 @@ describe('UserInfo', () => {
     secondPersonName: 'Марія',
     secondPersonSurname: 'Марієнко',
     phone: '+380991234567',
+    email: 'test@couple.ua',
   };
 
   it('renders full names and phone number correctly', () => {
@@ -133,7 +134,6 @@ describe('CoupleProfileView', () => {
     expect(
       screen.getByTestId('incomplete-profile-message'),
     ).toBeInTheDocument();
-    expect(screen.getByText(mockUser.email)).toBeInTheDocument();
     expect(screen.queryByTestId('user-info')).not.toBeInTheDocument();
   });
 

--- a/src/features/couple-profile-editing/ui/CoupleProfileView.tsx
+++ b/src/features/couple-profile-editing/ui/CoupleProfileView.tsx
@@ -42,7 +42,8 @@ export const CoupleProfileView: FC<CoupleProfileViewProps> = ({ onEdit }) => {
     !!firstPersonSurname &&
     !!secondPersonName &&
     !!secondPersonSurname &&
-    !!phone;
+    !!phone &&
+    !!email;
 
   const userInfoData = isProfileComplete ? getCoupleProfileData(user) : null;
 
@@ -52,8 +53,8 @@ export const CoupleProfileView: FC<CoupleProfileViewProps> = ({ onEdit }) => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        gap: 3.5,
-        pt: 3.5,
+        gap: '13px',
+        pt: '24px',
       }}
       data-testid="couple-profile-view"
     >
@@ -65,16 +66,12 @@ export const CoupleProfileView: FC<CoupleProfileViewProps> = ({ onEdit }) => {
           component="p"
           textAlign="center"
           data-testid="incomplete-profile-message"
+          maxWidth={510}
+          sx={{ mb: '10px' }}
         >
           У профілі бракує інформації.
           <br />
           Додайте основні дані про себе — це займе лише кілька хвилин.
-        </Typography>
-      )}
-
-      {email && (
-        <Typography variant="bodyLarge" component="p">
-          {email}
         </Typography>
       )}
 

--- a/src/features/couple-profile-editing/ui/UserInfo.tsx
+++ b/src/features/couple-profile-editing/ui/UserInfo.tsx
@@ -66,7 +66,7 @@ export const UserInfo: FC<UserInfoProps> = ({
         }}
       >
         <Typography variant="bodyDefault" width={153}>
-          Електрона пошта:
+          Електронна пошта:
         </Typography>
         <Typography variant="bodyLarge">{email}</Typography>
       </Box>

--- a/src/features/couple-profile-editing/ui/UserInfo.tsx
+++ b/src/features/couple-profile-editing/ui/UserInfo.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 
-import { Box, Typography } from '@mui/material';
-import { PhoneIcon } from '@phosphor-icons/react/dist/ssr/Phone';
+import { Box, Typography, styled } from '@mui/material';
 
 export interface UserInfoProps {
   firstPersonName: string;
@@ -9,7 +8,15 @@ export interface UserInfoProps {
   secondPersonName: string;
   secondPersonSurname: string;
   phone: string;
+  email: string;
 }
+
+const InfoWrapper = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  maxWidth: '510px',
+});
 
 export const UserInfo: FC<UserInfoProps> = ({
   firstPersonName,
@@ -17,35 +24,52 @@ export const UserInfo: FC<UserInfoProps> = ({
   secondPersonName,
   secondPersonSurname,
   phone,
+  email,
 }) => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: 3.5,
-      }}
-      data-testid="user-info"
-    >
-      <Typography variant="h3" fontWeight={500}>
-        {`${firstPersonName} ${firstPersonSurname}`}
-        {secondPersonName && secondPersonSurname && (
-          <> та {`${secondPersonName} ${secondPersonSurname}`}</>
-        )}
-      </Typography>
-
+    <InfoWrapper data-testid="user-info">
       <Box
         sx={{
           display: 'flex',
-          gap: 1.5,
           alignItems: 'center',
-          justifyContent: 'center',
+          gap: '24px',
+          padding: '13px 0 22px',
         }}
       >
-        <PhoneIcon size={24} weight="regular" color="currentColor" />
+        <Typography variant="bodyDefault" width={153}>
+          Ім’я та прізвища:
+        </Typography>
+        <Typography variant="bodyLarge">
+          {firstPersonName} {firstPersonSurname} та {secondPersonName}{' '}
+          {secondPersonSurname}
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '24px',
+          padding: '13px 0 22px',
+        }}
+      >
+        <Typography variant="bodyDefault" width={153}>
+          Телефон:
+        </Typography>
         <Typography variant="bodyLarge">{phone}</Typography>
       </Box>
-    </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '24px',
+          padding: '13px 0 22px',
+        }}
+      >
+        <Typography variant="bodyDefault" width={153}>
+          Електрона пошта:
+        </Typography>
+        <Typography variant="bodyLarge">{email}</Typography>
+      </Box>
+    </InfoWrapper>
   );
 };

--- a/src/pages-layer/couple/ui/CouplePage.tsx
+++ b/src/pages-layer/couple/ui/CouplePage.tsx
@@ -1,16 +1,38 @@
 'use client';
 
+import { Box, Container, styled } from '@mui/material';
+
+import { CoupleBooking } from '@/features/couple-booking/ui/CoupleBooking';
 import { CoupleProfileEditing } from '@/features/couple-profile-editing';
 
-import { Tabs } from '@/shared/ui';
+import { BreadCrumbs } from '@/shared/ui';
+
+const BREADCRUMBS_ITEMS = [
+  { href: '/', title: 'Головна' },
+  { href: '/profile', title: 'Наш профіль' },
+];
+
+const CoupleWrapper = styled(Container)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '13px',
+  paddingBottom: '60px',
+});
+
+const ContentWrapper = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '41px',
+});
 
 export const CouplePage = () => {
-  const tabs = [
-    {
-      label: 'Інформація про нас',
-      content: <CoupleProfileEditing />,
-    },
-    { label: 'Наші бронювання', content: <>Наші бронювання</> },
-  ];
-  return <Tabs tabs={tabs} initialIndex={0} />;
+  return (
+    <CoupleWrapper maxWidth="lg">
+      <BreadCrumbs items={BREADCRUMBS_ITEMS} />
+      <ContentWrapper>
+        <CoupleProfileEditing />
+        <CoupleBooking />
+      </ContentWrapper>
+    </CoupleWrapper>
+  );
 };

--- a/src/shared/tests/mockFormHelpers.ts
+++ b/src/shared/tests/mockFormHelpers.ts
@@ -1,5 +1,8 @@
 export const createMockHandleSubmit = () =>
-  jest.fn((fn) => (e: React.FormEvent<HTMLFormElement>) => {
-    fn(e);
-    e.preventDefault();
-  });
+  jest.fn(
+    (fn: (e: React.FormEvent<HTMLFormElement>) => void) =>
+      (e: React.FormEvent<HTMLFormElement>) => {
+        fn(e);
+        e.preventDefault();
+      },
+  );

--- a/src/shared/ui/TourCard/BookingButton.tsx
+++ b/src/shared/ui/TourCard/BookingButton.tsx
@@ -1,0 +1,31 @@
+import { Button, type ButtonProps, styled } from '@mui/material';
+
+export const BookingButton = styled(Button)<ButtonProps>(({ theme }) => ({
+  backgroundColor: theme.palette.accent[1],
+  boxShadow:
+    '0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12)',
+  color: theme.palette.common.white,
+  transition: 'all 0.3s ease',
+  '&:hover': {
+    backgroundColor: theme.palette.accent[1],
+    boxShadow:
+      '0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12)',
+    color: theme.palette.common.black,
+  },
+  '&:focus-visible': {
+    backgroundColor: theme.palette.accent[2],
+    boxShadow:
+      '0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0rgba(0, 0, 0, 0.12)',
+    color: theme.palette.common.black,
+  },
+  '&:active': {
+    backgroundColor: theme.palette.accent[1],
+    boxShadow: 'none',
+    color: theme.palette.common.black,
+  },
+  '&:disabled': {
+    backgroundColor: theme.palette.gray[800],
+    boxShadow: 'none',
+    color: theme.palette.common.black,
+  },
+}));

--- a/src/shared/ui/TourCard/BookingButton.tsx
+++ b/src/shared/ui/TourCard/BookingButton.tsx
@@ -15,7 +15,7 @@ export const BookingButton = styled(Button)<ButtonProps>(({ theme }) => ({
   '&:focus-visible': {
     backgroundColor: theme.palette.accent[2],
     boxShadow:
-      '0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0rgba(0, 0, 0, 0.12)',
+      '0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12)',
     color: theme.palette.common.black,
   },
   '&:active': {

--- a/src/shared/ui/TourCard/TourCard.tsx
+++ b/src/shared/ui/TourCard/TourCard.tsx
@@ -2,11 +2,8 @@
 
 import type { FC } from 'react';
 
-import Link from 'next/link';
-
 import {
   Box,
-  Button,
   Card,
   CardActions,
   CardContent,
@@ -16,14 +13,13 @@ import {
 } from '@mui/material';
 import { CalendarDotsIcon, MapPinLineIcon } from '@phosphor-icons/react';
 
-import type { TourPhoto } from '@/entities/tour/model/types';
-
-import { APP_ROUTE } from '@/shared/constants';
 import { OperatorLink } from '@/shared/ui';
 import { formattedDate } from '@/shared/utils';
 
 import Label from './Label';
+import { TourCardActions } from './TourCardActions';
 import { TourCardImage } from './TourCardImage';
+import type { TourCardProps } from './types';
 
 interface CardWrapperProps extends CardProps {
   isAvailable: boolean;
@@ -44,19 +40,16 @@ const CardWrapper = styled(Card, {
   boxShadow: 'none',
 
   ...(isAvailable && {
-    '&:has(.MuiButton-root:focus)': {
+    '&:has(.MuiButton-root:focus-visible)': {
       outline: `3px solid ${theme.palette.primary.dark}`,
     },
-
     '&:has(.MuiButton-root:active)': {
       outline: `3px solid ${theme.palette.primary.light}`,
     },
-
     '&:hover': {
       '& .tour-card-content-wrapper': {
         backgroundColor: 'rgba(54, 54, 54, 0.5)',
       },
-
       '& .tour-card-image-wrapper': {
         transform: 'scale(1.2) translate(25px, 38px)',
       },
@@ -66,19 +59,10 @@ const CardWrapper = styled(Card, {
 
 const ImageWrapper = styled(Box)({
   position: 'absolute',
-  top: 0,
-  left: 0,
-  width: '100%',
-  height: '100%',
-  zIndex: 0,
+  inset: 0,
   overflow: 'hidden',
   transition: 'transform 0.3s ease-in-out',
-});
-
-const PriceWrapper = styled(Box)({
-  display: 'flex',
-  gap: '8px',
-  alignItems: 'center',
+  zIndex: 0,
 });
 
 const ContentWrapper = styled(Box)({
@@ -100,21 +84,6 @@ const CardContentStyle = styled(CardContent)(({ theme }) => ({
   color: theme.palette.common.white,
   padding: 0,
 }));
-export interface TourCardProps {
-  id: number;
-  title: string;
-  availableSpots: number;
-  price: string;
-  photos: TourPhoto[];
-  startDate: string;
-  endDate: string;
-  countryName: string;
-  operator: {
-    name: string;
-    photo: string | null;
-    id: number;
-  };
-}
 
 export const TourCard: FC<TourCardProps> = ({
   id,
@@ -126,38 +95,42 @@ export const TourCard: FC<TourCardProps> = ({
   startDate,
   endDate,
   countryName,
+  bookingCount = 0,
+  variant = 'catalog',
 }) => {
-  const isAvailable = availableSpots !== 0;
+  const isAvailable = availableSpots > 0;
   const date = `${formattedDate(startDate)} — ${formattedDate(endDate)}`;
-  const mainPhoto = photos.find((photo) => photo.isMain === true) ?? photos[0];
+  const mainPhoto = photos.find((p) => p.isMain) ?? photos[0];
+
+  const handleDeleteTour = () => console.log(`Delete tour ${id}`);
+  const handleEditTour = () => console.log(`Edit tour ${id}`);
 
   return (
     <CardWrapper isAvailable={isAvailable}>
       <ImageWrapper className="tour-card-image-wrapper">
         <TourCardImage mainPhoto={mainPhoto} title={title} />
       </ImageWrapper>
-      <Label count={availableSpots} />
+
+      {variant === 'catalog' && <Label count={availableSpots} />}
+
       <ContentWrapper className="tour-card-content-wrapper">
         <CardContentStyle>
           <Typography
             align="center"
             variant="h3"
             component="h4"
-            sx={{
-              '&::first-letter': {
-                textTransform: 'uppercase',
-              },
-            }}
+            sx={{ '&::first-letter': { textTransform: 'uppercase' } }}
           >
             {title}
           </Typography>
+
           <Box
             sx={{
-              p: '0 8px',
               width: '100%',
               display: 'flex',
               flexDirection: 'column',
               gap: '12px',
+              px: '8px',
             }}
           >
             <Box
@@ -166,81 +139,68 @@ export const TourCard: FC<TourCardProps> = ({
                 justifyContent: 'space-between',
                 flexWrap: 'wrap',
                 gap: 1,
-                width: '100%',
               }}
             >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '8px',
-                }}
-              >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                 <CalendarDotsIcon size={24} />
-                <Typography
-                  variant="bodyDefault"
-                  sx={{
-                    lineHeight: '1',
-                    transform: 'translateY(1.2px)',
-                  }}
-                >
+                <Typography variant="bodyDefault" sx={{ lineHeight: 1 }}>
                   {date}
                 </Typography>
               </Box>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                }}
-              >
+
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                 <MapPinLineIcon size={24} />
                 <Typography
                   variant="bodyDefault"
-                  sx={{
-                    fontFamily: 'Inter',
-                    lineHeight: '1',
-                    transform: 'translateY(1px)',
-                    letterSpacing: '0.04em',
-                  }}
-                  component="p"
+                  sx={{ lineHeight: 1, letterSpacing: '0.04em' }}
                 >
                   {countryName}
                 </Typography>
               </Box>
             </Box>
-            <OperatorLink
-              variant="card"
-              id={operator.id}
-              name={operator.name}
-              photo={operator.photo}
-            />
+
+            {variant !== 'operator-tour' && (
+              <OperatorLink
+                variant="card"
+                id={operator.id}
+                name={operator.name}
+                photo={operator.photo}
+              />
+            )}
+
+            {variant === 'operator-tour' && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  gap: '8px',
+                  alignItems: 'center',
+                  pt: '8px',
+                  borderTop: '1px solid white',
+                }}
+              >
+                <Typography variant="bodyDefault" sx={{ pl: '8px' }}>
+                  Заброньовано:
+                </Typography>
+                <Typography variant="bodySmall">{`${bookingCount} місць`}</Typography>
+              </Box>
+            )}
           </Box>
-          <PriceWrapper>
-            <Typography variant="priceHighlight" component="p">
-              &#x20B4;
-            </Typography>
-            <Typography variant="priceHighlight" component="p">
-              {price}
-            </Typography>
-            <Typography variant="priceHighlight" component="p">
-              (за двох)
-            </Typography>
-          </PriceWrapper>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Typography variant="priceHighlight">&#x20B4;</Typography>
+            <Typography variant="priceHighlight">{price}</Typography>
+            <Typography variant="priceHighlight">(за двох)</Typography>
+          </Box>
         </CardContentStyle>
 
         <CardActions sx={{ p: 0 }}>
-          <Button
-            variant="contained"
-            color="primary"
-            size="large"
-            fullWidth
-            component={Link}
-            href={`${APP_ROUTE.CATALOG}${APP_ROUTE.TOUR}/${id}`}
-            disabled={!isAvailable}
-          >
-            Детальніше
-          </Button>
+          <TourCardActions
+            variant={variant}
+            id={id}
+            isAvailable={isAvailable}
+            onEdit={handleEditTour}
+            onDelete={handleDeleteTour}
+          />
         </CardActions>
       </ContentWrapper>
     </CardWrapper>

--- a/src/shared/ui/TourCard/TourCardActions.tsx
+++ b/src/shared/ui/TourCard/TourCardActions.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import type { FC } from 'react';
+
+import Link from 'next/link';
+
+import { Box, Button } from '@mui/material';
+
+import { APP_ROUTE } from '@/shared/constants';
+
+import { BookingButton } from './BookingButton';
+import type { TourCardVariantType } from './types';
+
+type TourCardActionsProps = {
+  variant: TourCardVariantType;
+  id: number;
+  isAvailable: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+export const TourCardActions: FC<TourCardActionsProps> = ({
+  variant,
+  id,
+  isAvailable,
+  onEdit,
+  onDelete,
+}) => {
+  if (variant === 'catalog') {
+    return (
+      <Button
+        variant="contained"
+        color="primary"
+        size="large"
+        fullWidth
+        component={Link}
+        href={`${APP_ROUTE.CATALOG}${APP_ROUTE.TOUR}/${id}`}
+        disabled={!isAvailable}
+      >
+        Детальніше
+      </Button>
+    );
+  }
+
+  if (variant === 'couple-booking') {
+    return (
+      <BookingButton
+        variant="contained"
+        color="primary"
+        size="large"
+        fullWidth
+        component={Link}
+        href={`${APP_ROUTE.CATALOG}${APP_ROUTE.TOUR}/${id}`}
+      >
+        Заброньовано
+      </BookingButton>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '20px',
+        width: '100%',
+      }}
+    >
+      <Button
+        variant="contained"
+        color="primary"
+        size="large"
+        fullWidth
+        onClick={onEdit}
+      >
+        Редагувати
+      </Button>
+
+      <Button
+        variant="outlined"
+        color="secondary"
+        size="large"
+        fullWidth
+        onClick={onDelete}
+        sx={(theme) => ({
+          color: theme.palette.common.white,
+          '&:hover, &:focus-visible, &:active': {
+            color: theme.palette.primaryExtended[950],
+          },
+        })}
+      >
+        Видалити
+      </Button>
+    </Box>
+  );
+};

--- a/src/shared/ui/TourCard/types.ts
+++ b/src/shared/ui/TourCard/types.ts
@@ -1,0 +1,24 @@
+import type { TourPhoto } from '@/entities/tour/model/types';
+
+export type TourCardVariantType =
+  | 'catalog'
+  | 'couple-booking'
+  | 'operator-tour';
+
+export type TourCardProps = {
+  id: number;
+  title: string;
+  availableSpots: number;
+  price: string;
+  photos: TourPhoto[];
+  startDate: string;
+  endDate: string;
+  countryName: string;
+  operator: {
+    name: string;
+    photo: string | null;
+    id: number;
+  };
+  bookingCount?: number;
+  variant?: TourCardVariantType;
+};

--- a/src/shared/ui/ToursCollection/ToursCollection.tsx
+++ b/src/shared/ui/ToursCollection/ToursCollection.tsx
@@ -10,6 +10,7 @@ export const ToursCollection: React.FC<ToursCollectionProps> = ({
   data,
   isFetchingNextPage,
   ref,
+  variantTourCard,
 }) => {
   return (
     <>
@@ -19,6 +20,7 @@ export const ToursCollection: React.FC<ToursCollectionProps> = ({
             <Grid key={tour.id} size={{ md: 4 }}>
               <TourCard
                 id={tour.id}
+                variant={variantTourCard}
                 title={tour.title}
                 availableSpots={tour.availableSpots}
                 price={tour.price}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added couple bookings section with breadcrumb-driven layout and empty-state screen
  * Tour cards: display variants, action controls, and a styled booking button; tours list forwards per-card variants

* **Bug Fixes**
  * Improved tour availability detection

* **UI/UX**
  * Profile page layout updated (tabs → linear breadcrumbs); removed outer container
  * Profile form restructured into two-column layout; email shown read-only and profile completeness now requires email
<!-- end of auto-generated comment: release notes by coderabbit.ai -->