### PR TITLE
tour-card: fix deleting booked tour

### DIFF
--- a/src/shared/ui/TourCard/TourCard.tsx
+++ b/src/shared/ui/TourCard/TourCard.tsx
@@ -213,6 +213,7 @@ export const TourCard: FC<TourCardProps> = ({
               title={title}
               operatorId={operator.id}
               isAvailable={isAvailable}
+              bookingCount={bookingCount}
             />
           )}
         </CardActions>

--- a/src/shared/ui/TourCard/TourCardActions.tsx
+++ b/src/shared/ui/TourCard/TourCardActions.tsx
@@ -20,6 +20,7 @@ type TourCardActionsProps = {
   tourId: number;
   title: string;
   isAvailable: boolean;
+  bookingCount: number;
 };
 
 export const TourCardActions: FC<TourCardActionsProps> = ({
@@ -28,6 +29,7 @@ export const TourCardActions: FC<TourCardActionsProps> = ({
   tourId,
   title,
   isAvailable,
+  bookingCount,
 }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
@@ -101,7 +103,7 @@ export const TourCardActions: FC<TourCardActionsProps> = ({
           size="large"
           fullWidth
           onClick={handleDeleteClick}
-          disabled={deleteTour.isPending}
+          disabled={bookingCount > 0 || deleteTour.isPending}
           sx={(theme) => ({
             color: theme.palette.common.white,
             '&:hover, &:focus-visible, &:active': {

--- a/src/shared/ui/ToursCollection/ToursCollection.tsx
+++ b/src/shared/ui/ToursCollection/ToursCollection.tsx
@@ -40,6 +40,7 @@ export const ToursCollection: FC<ToursCollectionProps<Tour>> = ({
                   startDate={tour.startDate}
                   endDate={tour.endDate}
                   countryName={getTranslation(tour.country.translations, 'uk')}
+                  bookingCount={tour.bookedSpots}
                   operator={{
                     id: tour.operator.id,
                     name: `${tour.operator.firstName} ${tour.operator.lastName}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Tours with active bookings can no longer be deleted. The Delete button is now disabled for tours that have existing bookings, preventing accidental removal of tours with reserved spots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->